### PR TITLE
Feature/19109 diagnostics

### DIFF
--- a/src/MontapackingShipping.php
+++ b/src/MontapackingShipping.php
@@ -20,12 +20,8 @@ class MontapackingShipping
     private Settings $settings;
 
     /**
-     * @var array
-     */
-    private array $_basic;
-
-    /**
      * @var MontaCheckout_Order
+     * @deprecated - Property is written but never read
      */
     private MontaCheckout_Order $_order;
 
@@ -58,12 +54,6 @@ class MontapackingShipping
         );
 
         $this->setSettings($settings);
-
-//        $this->_basic = [
-//            'Origin' => $this->getSettings()->getOrigin(),
-//            'Currency' => 'EUR',
-//            'Language' => $language,
-//        ];
     }
 
     /**
@@ -85,6 +75,7 @@ class MontapackingShipping
     /**
      * @param $total_incl
      * @param $total_excl
+     * @deprecated - Property is set but never used
      */
     public function setOrder($total_incl, $total_excl): void
     {
@@ -153,13 +144,6 @@ class MontapackingShipping
         $storeLocation = null;
 
         if (trim($this->address->postalCode) && (trim($this->address->houseNumber) || trim($this->address->street))) {
-//            $this->_basic = array_merge(
-//                $this->_basic,
-//                [
-//                    'ProductsOnStock' => ($onStock) ? 'TRUE' : 'FALSE',
-//                ]
-//            );
-
             if (!$this->getSettings()->getIsPickupPointsEnabled()) {
                 $this->getSettings()->setMaxPickupPoints(0);
             }

--- a/src/MontapackingShipping.php
+++ b/src/MontapackingShipping.php
@@ -12,8 +12,6 @@ use Monta\CheckoutApiWrapper\Objects\TimeFrame as MontaCheckout_TimeFrame;
 use Monta\CheckoutApiWrapper\Objects\PickupPoint as MontaCheckout_PickupPoint;
 use GuzzleHttp\Client;
 
-//require_once __DIR__ . '/../vendor/autoload.php'; // Adjust the path as needed
-
 class MontapackingShipping
 {
     /**
@@ -294,6 +292,7 @@ class MontapackingShipping
             'countrycode' => $this->address->countryCode,
             'products' => $this->_products,
             'excludeShippingDiscount' => $this->getSettings()->getExcludeShippingDiscount(),
+            Settings::SYSTEM_INFO_NAME => $this->getSettings()->getSystemInfo(),
             'showZeroCostsAsFree' => $this->getSettings()->getShowZeroCostsAsFree(),
             'currencySymbol' => $this->getSettings()->getCurrency()
         ];

--- a/src/MontapackingShipping.php
+++ b/src/MontapackingShipping.php
@@ -174,7 +174,7 @@ class MontapackingShipping
                         $timeframe->month,
                         $timeframe->dateFormatted,
                         $timeframe->dateOnlyFormatted,
-                        isset($timeframe->ShippingOptions) ? $timeframe->ShippingOptions : $timeframe->options
+                        $timeframe->ShippingOptions ?? $timeframe->options
                     );
                 }
             }
@@ -324,7 +324,10 @@ class MontapackingShipping
         return json_decode($response->getBody());
     }
 
-    private function getFallbackTimeframe()
+    /**
+     * @return MontaCheckout_TimeFrame
+     */
+    private function getFallbackTimeframe(): MontaCheckout_TimeFrame
     {
         $options = [new MontaCheckout_ShippingOption(
             'Standard Shipper',

--- a/src/Objects/Settings.php
+++ b/src/Objects/Settings.php
@@ -54,12 +54,12 @@ class Settings
     private string $currency;
 
     /**
-     * @var string
+     * @var bool
      */
     private bool $excludeShippingDiscount;
 
     /**
-     * @var string
+     * @var bool
      */
     private bool $showZeroCostsAsFree;
 
@@ -72,6 +72,9 @@ class Settings
      * @param string $googleKey
      * @param float $defaultCosts
      * @param string|null $webshopLanguage
+     * @param string $currency
+     * @param bool $excludeShippingDiscount
+     * @param bool $showZeroCostsAsFree
      */
     public function __construct(string $origin, string $user, string $password, bool $pickupPointsEnabled, int $maxPickupPoints, string $googleKey, float $defaultCosts,  ?string $webshopLanguage = 'nl-NL',string $currency = '€', bool $excludeShippingDiscount = false, bool $showZeroCostsAsFree = false)
     {
@@ -241,7 +244,7 @@ class Settings
     }
 
     /**
-     * @param bool excludeShippingDiscount
+     * @param bool $excludeShippingDiscount excludeShippingDiscount
      */
     public function setExcludeShippingDiscount(bool $excludeShippingDiscount): void
     {

--- a/src/Objects/Settings.php
+++ b/src/Objects/Settings.php
@@ -2,8 +2,12 @@
 
 namespace Monta\CheckoutApiWrapper\Objects;
 
+use Monta\CheckoutApiWrapper\Traits\SystemInfo;
+
 class Settings
 {
+    use SystemInfo;
+
     /**
      * @var string
      */

--- a/src/Objects/Settings.php
+++ b/src/Objects/Settings.php
@@ -244,7 +244,7 @@ class Settings
     }
 
     /**
-     * @param bool $excludeShippingDiscount excludeShippingDiscount
+     * @param bool $excludeShippingDiscount
      */
     public function setExcludeShippingDiscount(bool $excludeShippingDiscount): void
     {

--- a/src/Objects/ShippingOption.php
+++ b/src/Objects/ShippingOption.php
@@ -347,7 +347,7 @@ class ShippingOption
     }
 
     /**
-     * @param void $displayNameShort
+     * @param string $displayNameShort
      */
     public function setDisplayNameShort(string $displayNameShort): void
     {

--- a/src/Traits/SystemInfo.php
+++ b/src/Traits/SystemInfo.php
@@ -7,6 +7,9 @@ namespace Monta\CheckoutApiWrapper\Traits;
 
 trait SystemInfo
 {
+    /** @var string - Identifies the system information in the body */
+    public const SYSTEM_INFO_NAME = 'systemInformation';
+
     /** @var array */
     protected array $systemInfo = [];
 

--- a/src/Traits/SystemInfo.php
+++ b/src/Traits/SystemInfo.php
@@ -10,6 +10,21 @@ trait SystemInfo
     /** @var string - Identifies the system information in the body */
     public const SYSTEM_INFO_NAME = 'systemInformation';
 
+    /* Constants to determine the system info body. Reference these from client modules. */
+    public const CORE_SOFTWARE = 'coreSoftware';
+
+    public const CORE_VERSION = 'coreVersion';
+
+    public const CHECKOUT_API_WRAPPER_VERSION = 'checkoutApiWrapperVersion';
+
+    public const MODULE_NAME = 'moduleName';
+
+    public const MODULE_VERSION = 'moduleVersion';
+
+    public const PHP_VERSION = 'phpVersion';
+
+    public const OPERATING_SYSTEM = 'operatingSystem';
+
     /** @var array */
     protected array $systemInfo = [];
 

--- a/src/Traits/SystemInfo.php
+++ b/src/Traits/SystemInfo.php
@@ -41,6 +41,9 @@ trait SystemInfo
         $this->systemInfo = array_merge($this->systemInfo, $systemInfo);
     }
 
+    /**
+     * @return array
+     */
     public function getSystemInfo(): array
     {
         return $this->systemInfo;

--- a/src/Traits/SystemInfo.php
+++ b/src/Traits/SystemInfo.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @author Jacco.Amersfoort <jacco.amersfoort@monta.nl>
+ * @created 5/14/2025 14:08
+ */
+namespace Monta\CheckoutApiWrapper\Traits;
+
+trait SystemInfo
+{
+    /** @var array */
+    protected array $systemInfo = [];
+
+    public function setSystemInfo(array $systemInfo): void
+    {
+        $this->systemInfo = $systemInfo;
+    }
+
+    public function getSystemInfo(): array
+    {
+        return $this->systemInfo;
+    }
+}

--- a/src/Traits/SystemInfo.php
+++ b/src/Traits/SystemInfo.php
@@ -31,10 +31,14 @@ trait SystemInfo
         self::OPERATING_SYSTEM => PHP_OS
     ];
 
+    /**
+     * @param array $systemInfo
+     * @return void
+     */
     public function setSystemInfo(array $systemInfo): void
     {
-        // merge arrays (preserve duplicate keys)
-        $this->systemInfo += $systemInfo;
+        // merge arrays (prioritize parameter on duplicate key)
+        $this->systemInfo = array_merge($this->systemInfo, $systemInfo);
     }
 
     public function getSystemInfo(): array

--- a/src/Traits/SystemInfo.php
+++ b/src/Traits/SystemInfo.php
@@ -25,12 +25,16 @@ trait SystemInfo
 
     public const OPERATING_SYSTEM = 'operatingSystem';
 
-    /** @var array */
-    protected array $systemInfo = [];
+    /** @var array - Initialize with some global defaults */
+    protected array $systemInfo = [
+        self::PHP_VERSION => PHP_VERSION,
+        self::OPERATING_SYSTEM => PHP_OS
+    ];
 
     public function setSystemInfo(array $systemInfo): void
     {
-        $this->systemInfo = $systemInfo;
+        // merge arrays (preserve duplicate keys)
+        $this->systemInfo += $systemInfo;
     }
 
     public function getSystemInfo(): array

--- a/src/Traits/SystemInfo.php
+++ b/src/Traits/SystemInfo.php
@@ -8,7 +8,7 @@ namespace Monta\CheckoutApiWrapper\Traits;
 trait SystemInfo
 {
     /** @var string - Identifies the system information in the body */
-    public const SYSTEM_INFO_NAME = 'systemInformation';
+    public const SYSTEM_INFO_NAME = 'systemInfo';
 
     /* Constants to determine the system info body. Reference these from client modules. */
     public const CORE_SOFTWARE = 'coreSoftware';


### PR DESCRIPTION
- Add SystemInformation logic to Settings object
- Client modules should add system information to the deliveryOptions request
- Monta gateway must implement receiving this data and saving for client 
- Plus a little bit of cleanup on other unrelated code