### PR TITLE
Feature/90837 Fix Address geocoding coordinates caching

### DIFF
--- a/src/MontapackingShipping.php
+++ b/src/MontapackingShipping.php
@@ -90,10 +90,11 @@ class MontapackingShipping
      */
     public function setAddressFromArray(array $address): void
     {
-        $this->address = AddressHelper::convertAddress($address);
-
-        // Google Key must be included in address
-        $this->address->setGoogleApiKey($this->getSettings()->getGoogleKey());
+        $this->address = AddressHelper::convertAddress(
+            address: $address,
+            // Pass along api key if available
+            googleApiKey: $this->getSettings()->getGoogleKey()
+        );
     }
 
     /**

--- a/src/Objects/Address.php
+++ b/src/Objects/Address.php
@@ -199,10 +199,10 @@ class Address extends Objectable
     {
         if ($googleApiKey) {
             $this->googleApiKey = trim($googleApiKey);
-        }
 
-        // After setting Google Key, coordinates can be calculated
-        $this->setLongLat();
+            // After setting Google Key, coordinates can be calculated
+            $this->setLongLat();
+        }
 
         return $this;
     }

--- a/src/Objects/Address.php
+++ b/src/Objects/Address.php
@@ -47,18 +47,7 @@ class Address extends Objectable
      */
     public function setLongLat(): void
     {
-        // Get lat and long by address
-        $address = $this->houseNumber . ' ' . $this->houseNumberAddition . ', ' . $this->postalCode . ' ' . $this->countryCode;
-        // Add city, or it will always return "ZERO RESULTS" for Belgian zipcodes
-        // Google appears to ignore the city for other countries, only looks at zipcode. Yet it must be in the request
-        $prepAddr = $this->city . str_replace('  ', ' ', $address);
-        $prepAddr = str_replace(' ', '+', $prepAddr);
-
-        // If this address was geocoded before, use the cached result
-        if ($coords = Session::get($prepAddr)) {
-            // Array is simply 2 coordinates in an array, assign to variables
-            list($this->latitude, $this->longitude) = $coords;
-        } else {
+        $prepAddr = $this->getPrepareAddress();
             try {
                 $response = Guzzle::call(
                     route: "maps/api/geocode/json",
@@ -89,6 +78,19 @@ class Address extends Objectable
                 // Catch and ignore Exceptions, coordinates remain zero
             }
         }
+    /**
+     * @return string
+     */
+    public function getPrepareAddress(): string
+    {
+        // Get lat and long by address
+        $address = $this->houseNumber . ' ' . $this->houseNumberAddition . ', ' . $this->postalCode . ' ' . $this->countryCode;
+        // Add city, or it will always return "ZERO RESULTS" for Belgian zipcodes
+        // Google appears to ignore the city for other countries, only looks at zipcode. Yet it must be in the request
+        $prepAddress = $this->city . str_replace('  ', ' ', $address);
+
+        // Replace spaces with pluses to make it Google-friendly
+        return str_replace(' ', '+', $prepAddress);
     }
 
     /**

--- a/src/Objects/Address.php
+++ b/src/Objects/Address.php
@@ -48,6 +48,12 @@ class Address extends Objectable
     public function setLongLat(): void
     {
         $prepAddr = $this->getPrepareAddress();
+        $sessionPath = $prepAddr . "-coordinates";
+
+        // Get address from cache if already there
+        $coords = Session::get($sessionPath);
+        // If not, retrieve from API and write into cache
+        if (!$coords) {
             try {
                 $response = Guzzle::call(
                     route: "maps/api/geocode/json",
@@ -67,17 +73,24 @@ class Address extends Objectable
 
                 // Without geometry, Google Maps will not initalize. Pickup locations will be a plain list.
                 if (isset($result->geometry)) {
-                    $this->latitude = $result->geometry->location->lat;
-                    $this->longitude = $result->geometry->location->lng;
+                    $coords = [
+                        $result->geometry->location->lat,
+                        $result->geometry->location->lng,
+                    ];
 
-                    // Save this result in cache, so we don't have to load it again
-                    Session::save($prepAddr, [$this->latitude, $this->longitude]);
+                    // Save this result in cache, avoid multiple duplicate API calls
+                    Session::save($sessionPath, $coords);
                 }
             } catch (GuzzleException $ge) {
             } catch (\Exception $e) {
                 // Catch and ignore Exceptions, coordinates remain zero
             }
         }
+
+        // Whether retrieved from cache or from API, assign both variables here
+        list($this->latitude, $this->longitude) = $coords;
+    }
+
     /**
      * @return string
      */

--- a/src/Objects/Address.php
+++ b/src/Objects/Address.php
@@ -6,6 +6,7 @@ namespace Monta\CheckoutApiWrapper\Objects;
 use GuzzleHttp\Exception\GuzzleException;
 use Monta\CheckoutApiWrapper\Objects\Objectable as Objectable;
 use Monta\CheckoutApiWrapper\Service\Guzzle;
+use Monta\CheckoutApiWrapper\Service\Session;
 
 class Address extends Objectable
 {
@@ -79,6 +80,9 @@ class Address extends Objectable
                 if (isset($result->geometry)) {
                     $this->latitude = $result->geometry->location->lat;
                     $this->longitude = $result->geometry->location->lng;
+
+                    // Save this result in cache, so we don't have to load it again
+                    Session::save($prepAddr, [$this->latitude, $this->longitude]);
                 }
             } catch (GuzzleException $ge) {
             } catch (\Exception $e) {

--- a/src/Service/Address.php
+++ b/src/Service/Address.php
@@ -42,9 +42,10 @@ class Address
     /** Get normalized address from array
      *
      * @param array $address
+     * @param string|null $googleApiKey - Optionally pass API key for geocoding
      * @return WrapperAddress
      */
-    public static function convertAddress(array $address): WrapperAddress
+    public static function convertAddress(array $address, ?string $googleApiKey = null): WrapperAddress
     {
         $countryCode = self::extractValue($address, ['country', 'countryCode', 'countryId']);
 
@@ -82,7 +83,8 @@ class Address
         $postCode = self::extractValue($address, ['postCode', 'postalCode', 'zip', 'zipCode']) ?? '';
         $city = self::extractValue($address, ['city', 'city_id']) ?? '';
         $state = self::extractValue($address, ['state', 'state_id']) ?? '';
-        // Return address as array, exactly in the shape of an Address object (to splat into constructor)
+
+        // Return Address object
         return new WrapperAddress(
             street: trim($street ?? ''),
             houseNumber: trim($houseNr),
@@ -91,6 +93,7 @@ class Address
             city: trim($city),
             state: trim($state),
             countryCode: trim($countryCode),
+            googleApiKey: $googleApiKey,
         );
     }
 

--- a/src/Service/Session.php
+++ b/src/Service/Session.php
@@ -3,7 +3,7 @@
  * @author Jacco.Amersfoort <jacco.amersfoort@monta.nl>
  * @created 9/25/2025 10:43
  */
-namespace Monta\CheckoutApiWrapper\Objects;
+namespace Monta\CheckoutApiWrapper\Service;
 
 class Session
 {

--- a/src/Service/Session.php
+++ b/src/Service/Session.php
@@ -30,11 +30,7 @@ class Session
     public static function get(string $path): mixed
     {
         // Empty path should not ever be used as a path
-        if ($path) {
-            return null;
-        } else {
-            return $_SESSION[self::sessionPath($path)] ?? null;
-        }
+        return $path ? $_SESSION[self::sessionPath($path)] ?? null : null;
     }
 
     /** Convert user path into prefixed, usable path


### PR DESCRIPTION
- Functionality was built in a hurry, did not work properly. Now that's been fixed
- Merge thisnto refactor branch as well to reuse functionality
- Avoid making one Google Geocoding API without key (that always failed)