### PR TITLE
Feature/26282 Delivery promise workaround

### DIFF
--- a/src/MontapackingShipping.php
+++ b/src/MontapackingShipping.php
@@ -155,16 +155,20 @@ class MontapackingShipping
 
             $result = $this->call('shippingrates');
 
-            if (isset($result->timeframes)) {
-                foreach ($result->timeframes as $timeframe) {
-                    $timeframes[] = new MontaCheckout_TimeFrame(
-                        $timeframe->date,
-                        $timeframe->day,
-                        $timeframe->month,
-                        $timeframe->dateFormatted,
-                        $timeframe->dateOnlyFormatted,
-                        $timeframe->ShippingOptions ?? $timeframe->options ?? []
-                    );
+            // If API gave a correct result
+            if ($result && $this->lastResponseCode == 200) {
+                if (isset($result->timeframes)) {
+                    foreach ($result->timeframes as $stdTimeframe) {
+                        // If Timeframe has no day, optionally skip this
+                        // TODO divide its ShippingOptions among the other Timeframes, with each their own dates
+                        if ($stdTimeframe->day || !$this->getSettings()->getHideEmptyTimeframe()) {
+                            // Convert stdClass into TimeFrame class
+                            $timeframe = TimeFrame::construct((array)$stdTimeframe);
+                            // Options in API result are not using the correct property name
+                            $timeframe->setOptions($stdTimeframe->ShippingOptions ?? $stdTimeframe->options ?? []);
+                            $timeframes[] = $timeframe;
+                        }
+                    }
                 }
             }
 

--- a/src/Objects/Settings.php
+++ b/src/Objects/Settings.php
@@ -70,6 +70,16 @@ class Settings implements SystemInfoInterface
     private bool $hideDHLPackstations;
 
     /**
+     * @var string
+     */
+    private string $storeCollectLogo = '';
+
+    /**
+     * @var bool
+     */
+    private bool $hideEmptyTimeframe = false;
+
+    /**
      * @param string $origin
      * @param string $user
      * @param string $password
@@ -82,8 +92,11 @@ class Settings implements SystemInfoInterface
      * @param bool $excludeShippingDiscount
      * @param bool $showZeroCostsAsFree
      * @param bool $hideDHLPackstations
+     * @param string $storeCollectLogo - Optionally pass StoreCollect override image path (full absolute path)
+     * @param bool $hideEmptyTimeframe
+     * @deprecated - Use the factory method instead
      */
-    public function __construct(string $origin, string $user, string $password, bool $pickupPointsEnabled, int $maxPickupPoints, string $googleKey, float $defaultCosts,  ?string $webshopLanguage = 'nl-NL',string $currency = '€', bool $excludeShippingDiscount = false, bool $showZeroCostsAsFree = false, bool $hideDHLPackstations = false)
+    public function __construct(string $origin, string $user, string $password, bool $pickupPointsEnabled, int $maxPickupPoints, string $googleKey, float $defaultCosts, ?string $webshopLanguage = 'nl-NL', string $currency = '€', bool $excludeShippingDiscount = false, bool $showZeroCostsAsFree = false, bool $hideDHLPackstations = false, string $storeCollectLogo = '', bool $hideEmptyTimeframe = false)
     {
         $this->setOrigin($origin);
         $this->setUser($user);
@@ -97,6 +110,8 @@ class Settings implements SystemInfoInterface
         $this->setExcludeShippingDiscount($excludeShippingDiscount);
         $this->setShowZeroCostsAsFree($showZeroCostsAsFree);
         $this->setHideDHLPackstations($hideDHLPackstations);
+        $this->storeCollectLogo = $storeCollectLogo;
+        $this->hideEmptyTimeframe = $hideEmptyTimeframe;
     }
 
     /**
@@ -277,5 +292,13 @@ class Settings implements SystemInfoInterface
     public function setHideDHLPackstations(bool $hideDHLPackstations): void
     {
         $this->hideDHLPackstations = $hideDHLPackstations;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHideEmptyTimeframe(): bool
+    {
+        return $this->hideEmptyTimeframe;
     }
 }


### PR DESCRIPTION
## Summary
- optionally skip API timeframes that do not contain a day value
- add a settings flag to control hiding empty timeframes
- keep the wrapper behavior configurable for Magento consumers

## Why
The checkout can receive faulty timeframe entries without a delivery day for carriers like DHLDE. This workaround prevents those empty timeframes from surfacing until the upstream API issue is addressed.

## Notes
- targets issue #26282
- PR is intentionally scoped to the workaround commit only